### PR TITLE
feat(phase2): add AI search skills — answer-engine-optimization & structured-entities

### DIFF
--- a/skills/answer-engine-optimization/SKILL.md
+++ b/skills/answer-engine-optimization/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: answer-engine-optimization
+description: Optimize content to be extracted, cited, and recommended by AI answer engines. Use when asked to "optimize for AI search", "improve answer engine visibility", "make content citation-ready", "optimize for ChatGPT", "optimize for Perplexity", "optimize for AI Overviews", or "improve AI-generated recommendations".
+license: MIT
+metadata:
+  author: web-quality-skills
+  version: 0.1.0
+---
+
+# Answer Engine Optimization
+
+Structure and improve content so AI systems — ChatGPT, Perplexity, Gemini, Google AI Overviews, and others — can extract, cite, and recommend it with confidence.
+
+AEO is distinct from classic SEO. The goal is not ranking position but citation share, answer extraction quality, and recommendation readiness across AI-powered surfaces.
+
+## AEO fundamentals
+
+How AI answer engines evaluate content:
+
+| Signal | Classic SEO | AEO |
+|---|---|---|
+| Primary goal | Rank in SERPs | Be cited or recommended |
+| Content format | Keyword density | Extractable answer blocks |
+| Authority signals | Backlinks | Structured facts, source-of-truth pages |
+| Discovery layer | Crawl + index | Crawl + entity resolution + structured data |
+| Evaluation target | Page-level relevance | Sentence and block-level extractability |
+| Measurement | Rankings, clicks | Mention rate, citation rate, recommendation rate |
+
+## Answer block optimization
+
+The most important AEO principle: every important question a page targets should be answered directly, early, and in an extractable format.
+
+### Direct answer first
+
+```md
+❌ Poor — buries the answer:
+"When it comes to widget selection, there are many factors to consider,
+and over the years our team has developed expertise across various use cases..."
+
+✅ Good — leads with the answer:
+"Blue Widget Pro supports up to 10 concurrent connections and works with
+macOS 12+, Windows 10+, and Ubuntu 20.04+."
+```
+
+### Answer block patterns
+
+**Definition block** — use for "what is" queries:
+
+```md
+## What is [topic]?
+
+[Topic] is [concise definition in one to two sentences]. It [key
+differentiator or context]. [Optional: who it is for or when to use it.]
+```
+
+**How-it-works block** — use for "how does" queries:
+
+```md
+## How does [feature] work?
+
+[Feature] works by [clear mechanism]. When [trigger], the system
+[outcome]. This means [user benefit].
+```
+
+**Comparison block** — use for "vs" and "which is better" queries:
+
+```md
+## [Option A] vs [Option B]
+
+| | [Option A] | [Option B] |
+|---|---|---|
+| Best for | [use case] | [use case] |
+| Price | [range] | [range] |
+| [Key dimension] | [value] | [value] |
+| Limitation | [constraint] | [constraint] |
+```
+
+**Recommendation block** — use for "which should I choose" queries:
+
+```md
+## Which option is right for you?
+
+Choose [Option A] if:
+- [condition or use case]
+- [condition or use case]
+
+Choose [Option B] if:
+- [condition or use case]
+- [condition or use case]
+```
+
+## Content structure for AI extraction
+
+### Heading hierarchy
+
+Headings are the primary way AI systems parse page structure. Each heading should be a complete, plain-language question or topic statement.
+
+```md
+❌ Poor headings:
+## Overview
+## Details
+## More info
+
+✅ AEO-optimized headings:
+## What does Blue Widget Pro do?
+## Who is Blue Widget Pro designed for?
+## What are the system requirements?
+## How does Blue Widget Pro compare to Widget Lite?
+```
+
+### Sentence-level extractability
+
+Each key sentence should be independently meaningful without surrounding context.
+
+```md
+❌ Requires context to understand:
+"It supports the formats listed above and integrates with the systems
+mentioned in the previous section."
+
+✅ Self-contained:
+"Blue Widget Pro supports CSV, JSON, and XML import formats and integrates
+natively with Salesforce, HubSpot, and Zapier."
+```
+
+### Lists and tables
+
+Structured formats are the most reliably extracted content type.
+
+```md
+✅ Use lists for:
+- Features, capabilities, limitations
+- Requirements and prerequisites
+- Steps in a process
+- Options and variations
+
+✅ Use tables for:
+- Comparisons between options
+- Specs and technical attributes
+- Pricing tiers
+- Compatibility matrices
+```
+
+## Page types and AEO patterns
+
+### Product and service pages
+
+```md
+Required answer blocks:
+- What this product does (one to two sentences)
+- Who it is for
+- Key features or capabilities (list)
+- System requirements or compatibility
+- Pricing or pricing logic
+- How to get started
+- What it does not do (limitations)
+```
+
+### Category and solution pages
+
+```md
+Required answer blocks:
+- What this category covers
+- Who needs solutions in this category
+- Comparison of options (table)
+- How to choose (recommendation block)
+- Related categories or solutions
+```
+
+### Documentation and help pages
+
+```md
+Required answer blocks:
+- What this page explains (one sentence summary)
+- Prerequisites or requirements
+- Step-by-step instructions (numbered list)
+- Expected outcome
+- Common errors and fixes (FAQ format)
+- Related documentation links
+```
+
+## Citation quality signals
+
+AI systems weight these signals when deciding whether to cite a page:
+
+| Signal | What it means | How to implement |
+|---|---|---|
+| Factual specificity | Claims backed by numbers, specs, or evidence | Include version numbers, dates, measurements |
+| Internal consistency | Same facts stated consistently across the site | Audit for contradictions before publishing |
+| Authorship clarity | Content attributed to named experts or teams | Add author metadata and author pages |
+| Date freshness | Content is current and dated | Add datePublished / dateModified in schema and visibly |
+| Source attribution | External claims are referenced | Link to authoritative sources where relevant |
+| Entity alignment | Page entity matches schema, heading, and URL | Ensure schema name matches H1 and title |
+
+## Content audit checklist
+
+### Critical
+
+- [ ] Each important query is answered directly within the first paragraph of its section
+- [ ] No important answer requires reading multiple pages to assemble
+- [ ] Product, service, and category pages exist as dedicated pages
+- [ ] Pricing, compatibility, and limitation information is findable without contacting sales
+- [ ] Key specs and capabilities are in list or table format, not buried in prose
+
+### High priority
+
+- [ ] Every section heading is a plain-language question or descriptive topic statement
+- [ ] Comparison content exists for products or services where alternatives exist
+- [ ] Recommendation guidance (who should choose what) is explicit
+- [ ] FAQ sections cover the most common decision-blocking questions
+- [ ] Authorship and dates are visible and accurate
+
+### Medium priority
+
+- [ ] Answer blocks open each major section before elaborating
+- [ ] Tables are used for all multi-attribute comparisons
+- [ ] Structured data reinforces page entity type and key attributes
+- [ ] Internal links connect related product, category, and support content
+- [ ] Definitions exist for domain-specific terms
+
+### Ongoing
+
+- [ ] Monitor AI engine outputs for citations and recommendation patterns
+- [ ] Update answer blocks when product or policy changes occur
+- [ ] Retire or redirect outdated content rather than leaving it stale
+- [ ] Expand FAQ coverage based on support ticket patterns and search data
+
+## Common AEO anti-patterns
+
+| Anti-pattern | Why it fails | Fix |
+|---|---|---|
+| Marketing-first copy | Vague claims are not extractable | Lead with facts, not adjectives |
+| Answer buried in paragraph 4 | AI systems extract early blocks | Move answer to the first sentence |
+| Specs in PDFs or behind login | Not crawlable or extractable | Publish key specs on the web page |
+| "Contact us for pricing" | Blocks recommendation queries | Publish pricing tiers or ranges |
+| Thin category pages | No comparison or decision support | Add comparison tables and guidance |
+| Identical descriptions across variants | Ambiguous entity resolution | Give each variant a unique, specific description |
+| Stale documentation | Reduces citation trust | Add dates and review cadence |
+
+## AEO measurement
+
+Track AI search readiness using these outcome metrics:
+
+| Metric | What to measure | How |
+|---|---|---|
+| Brand mention rate | How often the brand appears in AI outputs | Prompt sampling across engines |
+| Citation rate | How often content is cited as a source | Prompt sampling + Perplexity citation check |
+| Recommendation rate | How often the product/service is recommended | Decision-query prompt sampling |
+| Generic category visibility | Visibility on non-branded queries | Category and comparison prompt sampling |
+
+## Tools
+
+| Tool | Use |
+|---|---|
+| Perplexity | Citation sampling and source attribution |
+| ChatGPT / Gemini | Answer quality and recommendation sampling |
+| Google AI Overviews | AIO inclusion and extraction testing |
+| Schema.org Validator | Structured data correctness |
+| Google Rich Results Test | Schema eligibility check |
+
+## References
+
+- `references/extractable-content.md` — how to write and structure content for AI extraction
+- `references/comparison-pages.md` — building comparison and decision-support pages
+- `references/faq-patterns.md` — FAQ and structured Q&A patterns for AEO
+- [`structured-entities`](../structured-entities/SKILL.md) — entity modeling and schema for AI search
+- [`ai-search-audit`](../ai-search-audit/SKILL.md) — full AI search readiness scoring and audit
+- [`llm-discovery`](../llm-discovery/SKILL.md) — discovery infrastructure for AI systems

--- a/skills/answer-engine-optimization/references/comparison-pages.md
+++ b/skills/answer-engine-optimization/references/comparison-pages.md
@@ -1,0 +1,184 @@
+# Comparison Pages
+
+A reference guide for building comparison and decision-support pages that AI answer engines use to answer "which is better", "X vs Y", and "what should I choose" queries.
+
+## Why comparison pages matter for AEO
+
+Comparison and decision queries are the highest-intent queries in any category. AI systems synthesize answers to these queries and always need a source. A well-structured comparison page is the most reliable way to appear in those syntheses.
+
+Without a comparison page, AI systems will synthesize comparisons using:
+- Competitor comparison pages
+- Review site aggregations
+- Forum discussions and comments
+
+Build your own comparison content to anchor the synthesis from your perspective.
+
+## Types of comparison content
+
+| Type | Query pattern | Content type |
+|---|---|---|
+| Head-to-head | "[Your product] vs [competitor]" | Comparison table + narrative |
+| Category overview | "Best [category] tools" | Multi-option comparison table |
+| Use-case fit | "Which [product] for [use case]?" | Conditional recommendation blocks |
+| Internal comparison | "[Product A] vs [Product B]" (own products) | Differentiation table |
+| Feature comparison | "Does [product] support [feature]?" | Feature matrix |
+
+## Comparison page structure
+
+### Required sections
+
+```md
+1. Quick summary table (first thing on the page)
+2. Who each option is for
+3. Detailed comparison by dimension
+4. Recommendation guidance (conditional on use case)
+5. FAQ
+6. Related comparisons (internal links)
+```
+
+### Quick summary table
+
+The first visible element should answer the comparison immediately:
+
+```md
+## [Product A] vs [Product B]: Quick summary
+
+| | [Product A] | [Product B] |
+|---|---|---|
+| Best for | [use case] | [use case] |
+| Price | [range] | [range] |
+| [Key dimension 1] | [value] | [value] |
+| [Key dimension 2] | [value] | [value] |
+| Free tier | Yes / No | Yes / No |
+| Open source | Yes / No | Yes / No |
+```
+
+### Dimension comparison
+
+Follow the summary with detail on each key dimension. Keep each section self-contained.
+
+```md
+### Performance
+
+[Product A] processes up to 10,000 requests per second on standard
+hardware with sub-5ms p99 latency. [Product B] processes up to
+4,000 requests per second with p99 latency under 12ms.
+
+For low-latency production workloads, [Product A] is the stronger
+choice. For teams with lower traffic requirements, [Product B]
+offers sufficient performance at a lower cost.
+```
+
+### Conditional recommendation block
+
+This is the highest-value block for AEO. AI systems use it to answer "which should I use" directly.
+
+```md
+## Which should you choose?
+
+Choose [Product A] if:
+- You need [specific condition]
+- Your team is familiar with [technology]
+- You require [specific capability]
+- You have a budget above [threshold]
+
+Choose [Product B] if:
+- You are [specific situation]
+- You need [alternative capability]
+- You are working within [constraint]
+- You are just getting started with [category]
+
+Both options work well if:
+- [shared fit condition]
+```
+
+### Honest limitations section
+
+Including your own product limitations increases citation credibility.
+
+```md
+## Limitations to consider
+
+**[Product A] limitations:**
+- [Specific limitation]
+- [Specific limitation]
+
+**[Product B] limitations:**
+- [Specific limitation]
+- [Specific limitation]
+```
+
+## Feature matrix for category pages
+
+```md
+## Feature comparison
+
+| Feature | [Product A] | [Product B] | [Product C] |
+|---|---|---|---|
+| [Feature 1] | ✓ | ✓ | — |
+| [Feature 2] | ✓ | — | ✓ |
+| [Feature 3] | — | ✓ | ✓ |
+| Price from | $X/mo | $Y/mo | $Z/mo |
+| Free tier | Yes | No | Yes |
+```
+
+Use `✓` for supported, `—` for not supported, and specific values for measurable attributes.
+
+## Comparison page schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Acme Monitor vs DataDog: Full Comparison 2026",
+  "description": "A detailed comparison of Acme Monitor and DataDog across pricing, features, performance, and use case fit.",
+  "datePublished": "2026-01-01",
+  "dateModified": "2026-04-01",
+  "author": {
+    "@type": "Organization",
+    "name": "Acme Corp"
+  }
+}
+```
+
+Add FAQPage schema for the FAQ section:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Acme Monitor better than DataDog?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Acme Monitor is better for teams that need lightweight API monitoring at lower cost. DataDog is better for teams that need full-stack observability including infrastructure and logs."
+      }
+    }
+  ]
+}
+```
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails for AEO |
+|---|---|
+| No clear recommendation | AI systems cannot synthesize a recommendation |
+| Biased only toward your product | Low citation credibility |
+| Vague dimension names | "Better performance" is not extractable |
+| No specific values in tables | Empty cells reduce utility |
+| Outdated competitor information | Degrades trust and accuracy |
+| No FAQ | Misses decision-blocking question formats |
+
+## Checklist
+
+- [ ] Quick summary comparison table is the first visible element
+- [ ] Every dimension uses specific measurable values
+- [ ] Conditional recommendation block covers at least two use-case scenarios
+- [ ] Limitations stated honestly for all options including your own
+- [ ] FAQ section covers common decision-blocking questions
+- [ ] Page is dated and kept current
+- [ ] Article and FAQPage schema present
+- [ ] Internal links connect to related product, category, and use-case pages
+- [ ] Competitor information is accurate and verifiable

--- a/skills/answer-engine-optimization/references/extractable-content.md
+++ b/skills/answer-engine-optimization/references/extractable-content.md
@@ -1,0 +1,193 @@
+# Extractable Content
+
+A reference guide for writing and structuring content that AI answer engines can reliably identify, extract, and cite.
+
+## What "extractable" means
+
+Extractable content is content that:
+- Can be lifted from its page context and remain accurate and self-sufficient
+- Directly answers a question without requiring surrounding context
+- Is structured in a way that signals its meaning without rendering
+
+AI systems process content at the block and sentence level, not the page level. Write accordingly.
+
+## The direct answer principle
+
+Every page section that targets a user question should open with a direct answer before elaborating.
+
+```md
+❌ Indirect — answer is buried:
+"There are many ways to approach API rate limiting. Teams often
+struggle with this topic because the right approach depends on
+infrastructure, traffic patterns, and business requirements.
+One popular approach is token bucket limiting, which..."
+
+✅ Direct — answer leads:
+"Token bucket is the most widely used rate limiting algorithm for
+REST APIs. It allows short bursts while enforcing a steady
+average rate, making it suitable for most API use cases."
+```
+
+## Sentence-level self-sufficiency
+
+Each key sentence must be independently accurate without antecedents or implicit context.
+
+```md
+❌ Requires context:
+"It supports the three protocols listed above and runs on
+the platforms mentioned in the requirements section."
+
+✅ Self-contained:
+"Acme Monitor supports REST, GraphQL, and gRPC and runs on
+macOS 12+, Windows 10+, and Ubuntu 20.04+."
+```
+
+## Structural signals AI systems use
+
+| Structure | Why it extracts well | When to use |
+|---|---|---|
+| Numbered lists | Clearly bounded, ordered items | Steps, processes, ranked options |
+| Bullet lists | Clearly bounded, parallel items | Features, requirements, options |
+| Definition blocks | Name + description pattern | Terms, concepts, entity introductions |
+| Tables | Multi-attribute, multi-entity comparison | Specs, pricing, compatibility, comparisons |
+| FAQ blocks | Explicit Q + A pairing | Common questions, decision support |
+| Code blocks | Exact, unambiguous technical content | Syntax, commands, config examples |
+
+## Writing patterns for extractable content
+
+### The definition pattern
+
+```md
+[Name] is [type of thing] that [does what] for [who].
+[Optional: key differentiator or context sentence.]
+
+Example:
+Blue Widget Pro is a hardware monitoring device that tracks
+power usage and temperature for industrial equipment. It
+supports up to 64 sensor inputs and runs without a cloud
+dependency.
+```
+
+### The capability pattern
+
+```md
+[Name] supports:
+- [capability one]
+- [capability two]
+- [capability three]
+
+Example:
+Acme API Monitor supports:
+- HTTP/HTTPS, WebSocket, and TCP monitoring
+- Alert routing via email, Slack, and PagerDuty
+- Custom check intervals from 10 seconds to 24 hours
+```
+
+### The constraint pattern
+
+Explicitly stating limitations increases citation trust.
+
+```md
+[Name] does not support:
+- [limitation one]
+- [limitation two]
+
+Example:
+Acme API Monitor does not support:
+- On-premise deployment (cloud-only)
+- Monitoring of private network endpoints without a gateway agent
+- SNMP or legacy TCP/IP protocol monitoring
+```
+
+### The requirement pattern
+
+```md
+[Name] requires:
+- [requirement]
+- [requirement]
+
+Compatible with:
+| Platform | Minimum version |
+|---|---|
+| macOS | 12.0 (Monterey) |
+| Windows | 10 (build 19041+) |
+| Ubuntu | 20.04 LTS |
+```
+
+### The outcome pattern
+
+```md
+When [trigger or action], [outcome].
+
+Example:
+When a monitored endpoint returns three consecutive errors,
+Acme Monitor sends an alert within 30 seconds and logs the
+full response for debugging.
+```
+
+## Content that extracts poorly
+
+| Pattern | Why it extracts poorly |
+|---|---|
+| Long paragraphs with no structure | AI systems cannot identify extract boundaries |
+| Vague adjectives without specifics | "Powerful" and "easy" cannot be cited as facts |
+| "Learn more" / "contact us" dead ends | Blocks resolution of key questions |
+| PDFs with key specs | Not crawlable or parseable by most AI systems |
+| JavaScript-rendered content | May not be fetched in text-based retrieval |
+| Locked-in prose without headers | No structural anchors for extraction |
+| Implicit comparisons | Too ambiguous to cite honestly |
+
+## Factual density
+
+High-factual-density writing extracts better.
+
+```md
+❌ Low density:
+"Our product has been praised by many companies for its
+impressive performance and flexibility in a variety of
+demanding enterprise environments."
+
+✅ High density:
+"Acme Monitor is used by over 400 engineering teams. Its
+average detection-to-alert latency is under 15 seconds at
+p99 across monitored endpoints."
+```
+
+## Metadata that supports extraction
+
+```html
+<!-- Date signals -->
+<time datetime="2026-03-01">March 2026</time>
+
+<!-- Author signals -->
+<span itemprop="author">Sarah Chen</span>
+
+<!-- Canonical anchor -->
+<link rel="canonical" href="https://acme.com/docs/rate-limiting" />
+```
+
+And in JSON-LD:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "datePublished": "2026-03-01",
+  "dateModified": "2026-04-01",
+  "author": {
+    "@type": "Person",
+    "name": "Sarah Chen"
+  }
+}
+```
+
+## Checklist
+
+- [ ] Every targeted question answered in the opening sentence of its section
+- [ ] No key fact requires assembling across multiple pages
+- [ ] Features, specs, and requirements in list or table format
+- [ ] Product names identical in body copy, schema, and headings
+- [ ] Limitations and constraints stated explicitly
+- [ ] Dates visible and current on time-sensitive pages
+- [ ] All important content accessible without JavaScript rendering
+- [ ] No key information locked in PDFs or behind authentication

--- a/skills/answer-engine-optimization/references/faq-patterns.md
+++ b/skills/answer-engine-optimization/references/faq-patterns.md
@@ -1,0 +1,203 @@
+# FAQ Patterns
+
+A reference guide for building FAQ and structured Q&A content that AI answer engines reliably extract, cite, and use in answer synthesis.
+
+## Why FAQ content extracts well
+
+FAQ blocks have the highest extraction rate of any content pattern because:
+- The question provides the extraction anchor
+- The answer is bounded and self-contained
+- The Q&A format mirrors how answer engines compose outputs
+- FAQPage schema creates machine-readable Q+A pairs
+
+## FAQ placement strategy
+
+| Page type | Where to add FAQ |
+|---|---|
+| Product pages | After features and specs |
+| Category pages | After comparison tables |
+| Pricing pages | After the pricing table |
+| Documentation pages | After each major procedure |
+| Comparison pages | After the recommendation block |
+| Blog posts | At the end of the article |
+
+## FAQ question types
+
+Cover all five question types for complete AEO coverage:
+
+| Type | Example | Why it matters |
+|---|---|---|
+| Definition | "What is [product]?" | Anchors entity recognition |
+| Capability | "Does [product] support [feature]?" | Feeds feature queries |
+| Comparison | "How does [product] compare to [X]?" | Feeds comparison queries |
+| Decision | "Is [product] right for [use case]?" | Feeds recommendation queries |
+| Troubleshooting | "Why is [thing] not working?" | Feeds support queries |
+
+## Writing FAQ answers
+
+### Answer length guide
+
+| Query type | Ideal answer length |
+|---|---|
+| Definition | 1–3 sentences |
+| Yes/No capability | 1 sentence + context |
+| Comparison | 2–4 sentences or a short table |
+| Decision/recommendation | 3–5 sentences with conditional guidance |
+| Process/how-to | Numbered steps, 3–7 items |
+
+### The yes/no + context pattern
+
+Never answer with only "yes" or "no". Always add the useful context.
+
+```md
+❌ Too thin:
+Q: Does Acme Monitor support GraphQL?
+A: Yes.
+
+✅ Useful:
+Q: Does Acme Monitor support GraphQL?
+A: Yes. Acme Monitor supports GraphQL monitoring via HTTP endpoint
+checks and response body validation. It can assert on specific
+fields in the response JSON and alert on unexpected values or
+latency thresholds.
+```
+
+### The conditional recommendation pattern
+
+```md
+Q: Is Acme Monitor right for a small startup?
+
+A: Yes, if you are running fewer than 20 endpoints and want a
+quick setup without infrastructure overhead. Acme Monitor's free
+tier covers up to 10 monitors with 1-minute check intervals.
+For larger teams or more complex routing needs, consider upgrading
+to the Pro plan or evaluating full-stack observability platforms.
+```
+
+### The comparison answer pattern
+
+```md
+Q: How does Acme Monitor compare to Pingdom?
+
+A: Acme Monitor focuses on API-level monitoring — it validates
+response bodies, headers, and latency for REST, GraphQL, and gRPC
+endpoints. Pingdom focuses on uptime monitoring for web pages and
+simple HTTP endpoints. Choose Acme Monitor for API teams and
+Pingdom for website uptime use cases.
+```
+
+## FAQ HTML pattern
+
+```html
+<section class="faq">
+  <h2>Frequently asked questions</h2>
+
+  <details>
+    <summary>What does Acme Monitor do?</summary>
+    <p>
+      Acme Monitor checks the availability, latency, and response
+      correctness of REST, GraphQL, and gRPC APIs on a schedule
+      you define. It sends alerts when checks fail and logs
+      response data for debugging.
+    </p>
+  </details>
+
+  <details>
+    <summary>Does Acme Monitor support on-premise deployment?</summary>
+    <p>
+      No. Acme Monitor is a cloud-hosted service. For monitoring
+      private network endpoints, a gateway agent is available on
+      Pro and Enterprise plans.
+    </p>
+  </details>
+</section>
+```
+
+## FAQPage schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What does Acme Monitor do?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Acme Monitor checks the availability, latency, and response correctness of REST, GraphQL, and gRPC APIs. It sends alerts when checks fail and logs response data for debugging."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Acme Monitor support on-premise deployment?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Acme Monitor is a cloud-hosted service. A gateway agent is available for monitoring private network endpoints on Pro and Enterprise plans."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Acme Monitor compare to Pingdom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Acme Monitor focuses on API-level monitoring including response body validation and GraphQL support. Pingdom focuses on website uptime monitoring. Choose Acme Monitor for API teams and Pingdom for website uptime use cases."
+      }
+    }
+  ]
+}
+```
+
+## Recommended FAQ coverage per page type
+
+### Product page FAQ (minimum 5 questions)
+
+```md
+1. What does [product] do?
+2. Who is [product] designed for?
+3. What are [product]'s system requirements?
+4. How does [product] compare to [main alternative]?
+5. How much does [product] cost?
+6. What does [product] not support?
+7. How do I get started with [product]?
+```
+
+### Pricing page FAQ (minimum 4 questions)
+
+```md
+1. What is included in the free tier?
+2. Can I switch plans later?
+3. Is there a contract or commitment?
+4. What payment methods are accepted?
+5. What happens if I exceed my plan limits?
+```
+
+### Category page FAQ (minimum 4 questions)
+
+```md
+1. What is [category]?
+2. What are the best [category] tools?
+3. How do I choose between [option A] and [option B]?
+4. What should I look for in a [category] solution?
+```
+
+## FAQ anti-patterns
+
+| Anti-pattern | Why it fails | Fix |
+|---|---|---|
+| Questions no one asks | Doesn't address real queries | Base on support tickets and search data |
+| One-word answers | Not extractable or useful | Always add context after yes/no |
+| Duplicate FAQ across pages | Entity and answer ambiguity | Tailor FAQ to each page's specific entity |
+| Schema answer differs from visible text | Schema mismatch | Keep schema text and visible text identical |
+| FAQ buried below the fold | Reduces extraction chance | Place FAQ near top or after key sections |
+| No FAQ on key commercial pages | Misses decision-query coverage | Add FAQ to all product and pricing pages |
+
+## Checklist
+
+- [ ] FAQ covers all five question types: definition, capability, comparison, decision, troubleshooting
+- [ ] Every yes/no answer includes contextual detail
+- [ ] All conditional recommendation answers include at least two use-case scenarios
+- [ ] FAQPage schema is present and matches visible content exactly
+- [ ] FAQ placed after key sections on commercial pages
+- [ ] Questions are based on real user queries, not marketing assumptions
+- [ ] FAQ updated when product, pricing, or capabilities change

--- a/skills/structured-entities/SKILL.md
+++ b/skills/structured-entities/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: structured-entities
+description: Model and publish structured entity pages and schema markup for AI search and answer engine readiness. Use when asked to "add structured data", "implement schema markup", "create entity pages", "improve organization schema", "add product schema", "build source-of-truth pages", or "improve AI entity recognition".
+license: MIT
+metadata:
+  author: web-quality-skills
+  version: 0.1.0
+---
+
+# Structured Entities
+
+Build and maintain structured entity pages and JSON-LD schema so AI systems can confidently resolve, describe, and recommend the site's main entities — organizations, products, services, categories, authors, and more.
+
+Structured entities are the foundation of AI-search authority. A site that cannot resolve its core entities clearly is unlikely to be cited or recommended reliably regardless of content quality.
+
+## Why structured entities matter for AI search
+
+| Without structured entities | With structured entities |
+|---|---|
+| AI must infer what the brand does from prose | AI resolves the brand from structured facts |
+| Product names may be confused with competitors | Products have unique, schema-reinforced identities |
+| Category coverage is ambiguous | Categories map to clear solution areas |
+| Author authority is unclear | Authors have linked identity pages |
+| Citations may go to competitors | Source-of-truth pages anchor citations |
+
+## Entity types and priority
+
+### Priority 1 — always required
+
+| Entity | Page type | Schema type |
+|---|---|---|
+| Organization / brand | `/about`, `/company` | `Organization` |
+| Website identity | Homepage | `WebSite` |
+| Products | `/products/[name]` | `Product` |
+| Services | `/services/[name]` | `Service` |
+
+### Priority 2 — required for most sites
+
+| Entity | Page type | Schema type |
+|---|---|---|
+| FAQ content | Any page with Q&A | `FAQPage` |
+| How-to content | Process or guide pages | `HowTo` |
+| Articles and guides | Blog, docs, editorial | `Article` |
+| Breadcrumbs | All inner pages | `BreadcrumbList` |
+| Authors | Blog, editorial, docs | `Person` |
+
+### Priority 3 — situational
+
+| Entity | Page type | Schema type |
+|---|---|---|
+| Local business | Location pages | `LocalBusiness` |
+| Software application | App or tool pages | `SoftwareApplication` |
+| Reviews | Product or service pages | `Review`, `AggregateRating` |
+| Course or learning content | Educational pages | `Course` |
+
+## Organization schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Acme Corp",
+  "url": "https://acme.com",
+  "logo": "https://acme.com/logo.png",
+  "description": "Acme Corp builds developer tools for API testing and monitoring.",
+  "foundingDate": "2019",
+  "sameAs": [
+    "https://twitter.com/acmecorp",
+    "https://linkedin.com/company/acmecorp",
+    "https://github.com/acmecorp"
+  ],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "customer support",
+    "email": "support@acme.com",
+    "url": "https://acme.com/support"
+  }
+}
+```
+
+## WebSite schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Acme Corp",
+  "url": "https://acme.com",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://acme.com/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+```
+
+## Product schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "Acme API Monitor Pro",
+  "url": "https://acme.com/products/api-monitor-pro",
+  "image": "https://acme.com/images/api-monitor-pro.png",
+  "description": "Acme API Monitor Pro provides real-time uptime monitoring and alerting for REST, GraphQL, and gRPC APIs.",
+  "brand": {
+    "@type": "Brand",
+    "name": "Acme Corp"
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "49.00",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
+  },
+  "additionalProperty": [
+    {
+      "@type": "PropertyValue",
+      "name": "Supported protocols",
+      "value": "REST, GraphQL, gRPC"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Check interval",
+      "value": "30 seconds"
+    }
+  ]
+}
+```
+
+## Article schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Monitor GraphQL APIs in Production",
+  "description": "A practical guide to monitoring GraphQL API health, latency, and error rates.",
+  "author": {
+    "@type": "Person",
+    "name": "Sarah Chen",
+    "url": "https://acme.com/authors/sarah-chen"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Acme Corp",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://acme.com/logo.png"
+    }
+  },
+  "datePublished": "2025-11-01",
+  "dateModified": "2026-03-15"
+}
+```
+
+## BreadcrumbList schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://acme.com"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Products",
+      "item": "https://acme.com/products"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "API Monitor Pro",
+      "item": "https://acme.com/products/api-monitor-pro"
+    }
+  ]
+}
+```
+
+## Entity consistency rules
+
+| Check | Rule |
+|---|---|
+| Name consistency | `schema name` = `<h1>` = `<title>` = navigation label |
+| URL consistency | `schema url` = canonical tag = primary internal link |
+| Description accuracy | Schema description reflects what the page actually says |
+| Date accuracy | datePublished and dateModified reflect real dates |
+| Rating accuracy | Only add aggregateRating if real reviews exist |
+| Offer accuracy | Prices and availability must match live site values |
+
+## Entity audit checklist
+
+### Critical
+
+- [ ] Organization schema present on About or homepage
+- [ ] WebSite schema present on homepage
+- [ ] Product/Service schema present on all product and service pages
+- [ ] Schema names match H1 headings
+- [ ] Schema URLs match canonical tags
+
+### High priority
+
+- [ ] Article schema on all editorial content
+- [ ] BreadcrumbList on all inner pages
+- [ ] Author schema on editorial and documentation pages
+- [ ] FAQ schema on pages with Q&A content
+- [ ] sameAs links on Organization schema
+
+### Medium priority
+
+- [ ] additionalProperty on products for key specs
+- [ ] dateModified kept current on all schema
+- [ ] SoftwareApplication schema for any app or tool
+- [ ] Person schema for all named contributors
+- [ ] Review and AggregateRating where genuine ratings exist
+
+### Ongoing
+
+- [ ] Validate schema after every major content update
+- [ ] Remove schema for deprecated or retired pages
+- [ ] Monitor for schema warnings in Google Search Console
+- [ ] Audit entity name consistency across schema, headings, and nav
+
+## Common entity mistakes
+
+| Mistake | Why it matters | Fix |
+|---|---|---|
+| Schema name differs from H1 | Entity ambiguity | Match exactly |
+| Empty or generic descriptions | Weak entity signal | Write specific, accurate descriptions |
+| Ratings without real reviews | Misleading | Remove until genuine |
+| Prices not kept current | Breaks recommendation trust | Automate or review regularly |
+| sameAs links to wrong profiles | Misidentification | Verify each external link |
+| No author on editorial content | Weak authority signal | Add author pages and schema |
+
+## Validation tools
+
+| Tool | Use |
+|---|---|
+| [Google Rich Results Test](https://search.google.com/test/rich-results) | Validate schema eligibility |
+| [Schema.org Validator](https://validator.schema.org/) | Full schema correctness check |
+| [Google Search Console](https://search.google.com/search-console) | Monitor schema errors at scale |
+
+## References
+
+- `references/organization.md` — organization and brand entity patterns in depth
+- `references/product.md` — product and service entity modeling
+- `references/faq-howto.md` — FAQ, HowTo, and structured Q&A schema
+- [`answer-engine-optimization`](../answer-engine-optimization/SKILL.md) — content structure for AI citation
+- [`ai-search-audit`](../ai-search-audit/SKILL.md) — full AI search readiness scoring
+- [Schema.org](https://schema.org/)
+- [Google Structured Data Documentation](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)

--- a/skills/structured-entities/references/faq-howto.md
+++ b/skills/structured-entities/references/faq-howto.md
@@ -1,0 +1,230 @@
+# FAQ, HowTo & Structured Q&A Schema
+
+> Deep-reference for `skills/structured-entities/SKILL.md`
+
+## Why FAQ and HowTo Schema Win AI Citations
+
+FAQ and HowTo schema are the highest-yield structured data types for AI answer engines. AI models prefer to pull answers from clearly delineated Q&A and step-by-step content because it maps directly to user query patterns. A well-structured FAQ can appear verbatim in AI-generated answers, making it a primary vector for brand visibility in AI search.
+
+## FAQPage Schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is Widget Pro and who is it for?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Widget Pro is an enterprise-grade widget management platform designed for teams of 10 or more. It includes cloud sync, real-time collaboration, and a 5-year warranty. It is ideal for operations managers and IT teams needing reliable widget infrastructure."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much does Widget Pro cost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Widget Pro is priced at AUD $299 per unit with volume discounts available for orders of 10 or more. Enterprise licensing starts at AUD $2,500 per year. A free 30-day trial is available with no credit card required."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Widget Pro integrate with existing systems?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Widget Pro integrates with Salesforce, HubSpot, Slack, and Zapier out of the box. A REST API and webhooks are available for custom integrations. Full API documentation is at https://example.com/docs/api."
+      }
+    }
+  ]
+}
+```
+
+## FAQ Writing Rules for AI Extraction
+
+AI models evaluate FAQ answers on these criteria:
+
+| Criterion | Bad Example | Good Example |
+|-----------|-------------|---------------|
+| Question specificity | "What is this?" | "What does Widget Pro do for enterprise teams?" |
+| Answer completeness | "It's great for teams." | Full sentence with context, numbers, and next step |
+| Answer length | 3 words | 40–120 words (sweet spot for AI extraction) |
+| Contains URLs | None | Direct link to relevant page |
+| Uses entity names | "our product" | Brand name + product name in full |
+| Avoids hedging | "It might work with..." | "Widget Pro integrates with X, Y, Z" |
+
+## HowTo Schema
+
+For instructional content that AI models surface in step-by-step responses:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Set Up Widget Pro in Under 10 Minutes",
+  "description": "A step-by-step guide to installing and configuring Widget Pro for your team.",
+  "totalTime": "PT10M",
+  "estimatedCost": {
+    "@type": "MonetaryAmount",
+    "currency": "AUD",
+    "value": "0"
+  },
+  "tool": [
+    { "@type": "HowToTool", "name": "Widget Pro installer" },
+    { "@type": "HowToTool", "name": "Admin credentials" }
+  ],
+  "supply": [
+    { "@type": "HowToSupply", "name": "Widget Pro license key" }
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Download the installer",
+      "text": "Go to example.com/download and click Download Widget Pro. Select your operating system version.",
+      "url": "https://example.com/setup#step1",
+      "image": "https://example.com/images/setup-step1.png"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Run the installer",
+      "text": "Double-click the downloaded file and follow the on-screen prompts. Accept the license agreement and choose your installation directory.",
+      "url": "https://example.com/setup#step2",
+      "image": "https://example.com/images/setup-step2.png"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Enter your license key",
+      "text": "When prompted, paste your license key from your welcome email. Click Activate. The system will validate online and complete setup.",
+      "url": "https://example.com/setup#step3",
+      "image": "https://example.com/images/setup-step3.png"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Invite your team",
+      "text": "Navigate to Settings > Team and click Invite Members. Enter email addresses and assign roles. Team members will receive an invitation email.",
+      "url": "https://example.com/setup#step4",
+      "image": "https://example.com/images/setup-step4.png"
+    }
+  ]
+}
+```
+
+## HowToSection for Multi-Part Guides
+
+For longer guides with sections:
+
+```json
+"step": [
+  {
+    "@type": "HowToSection",
+    "name": "Installation",
+    "itemListElement": [
+      { "@type": "HowToStep", "name": "Download", "text": "..." },
+      { "@type": "HowToStep", "name": "Install", "text": "..." }
+    ]
+  },
+  {
+    "@type": "HowToSection",
+    "name": "Configuration",
+    "itemListElement": [
+      { "@type": "HowToStep", "name": "Set preferences", "text": "..." },
+      { "@type": "HowToStep", "name": "Connect integrations", "text": "..." }
+    ]
+  }
+]
+```
+
+## QAPage Schema (Community Q&A)
+
+For pages with a single accepted answer (support, community):
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "QAPage",
+  "mainEntity": {
+    "@type": "Question",
+    "name": "Why is Widget Pro showing a sync error?",
+    "text": "I installed Widget Pro yesterday and it keeps showing sync error 403. I'm on Windows 11.",
+    "answerCount": 2,
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "Error 403 on sync usually means your firewall is blocking the Widget Pro sync endpoint. Add an exception for sync.example.com:443 in your firewall settings and restart the service.",
+      "upvoteCount": 47,
+      "dateCreated": "2024-10-01",
+      "author": { "@type": "Person", "name": "Acme Support" }
+    },
+    "suggestedAnswer": [
+      {
+        "@type": "Answer",
+        "text": "Also check that your proxy settings aren't intercepting SSL traffic.",
+        "upvoteCount": 12
+      }
+    ]
+  }
+}
+```
+
+## SpecialAnnouncement (for time-sensitive AI visibility)
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SpecialAnnouncement",
+  "name": "Widget Pro 4.0 Release",
+  "text": "Widget Pro 4.0 is now available with 40% faster sync and new mobile apps for iOS and Android.",
+  "datePosted": "2025-01-15",
+  "expires": "2025-03-31",
+  "category": "https://www.wikidata.org/wiki/Q10373",
+  "announcementLocation": { "@id": "https://example.com/#organization" }
+}
+```
+
+## FAQ Topic Coverage Strategy
+
+AI models extract FAQ answers when they match query intent. Cover all five intent categories:
+
+| Intent Category | Example Questions | AI Use Case |
+|-----------------|-------------------|--------------|
+| What is it | "What does X do?", "What is X?" | Definition queries |
+| How much / pricing | "How much does X cost?", "Is X free?" | Commerce queries |
+| Comparison | "X vs Y?", "Is X better than Y?" | Comparison queries |
+| How to use | "How do I set up X?", "How to integrate X" | Task queries |
+| Troubleshooting | "Why is X not working?", "X error fix" | Support queries |
+| Eligibility | "Who can use X?", "Requirements for X" | Qualification queries |
+
+## Common FAQ/HowTo Schema Mistakes
+
+| Mistake | AI Impact | Fix |
+|---------|-----------|-----|
+| Question is vague | Not matched to real queries | Use exact user phrasing from search data |
+| Answer is one sentence | Insufficient for AI extraction | Write 40–120 word complete answers |
+| Answers use "we" / "our" | Brand unclear to AI | Name brand explicitly in every answer |
+| HowTo steps have no images | Lower visual result eligibility | Add step screenshots |
+| FAQ on every page | Diluted authority | One canonical FAQ page per topic |
+| No `totalTime` on HowTo | Missing quick-answer metadata | Always add ISO 8601 duration |
+| Mixed FAQPage + HowTo | Schema type confusion | Use separate pages for each type |
+
+## Checklist
+
+- [ ] FAQPage has at least 5 questions covering all intent categories
+- [ ] Each answer is 40–120 words
+- [ ] Answers name the brand and product explicitly (no "we" / "our")
+- [ ] Answers include specific numbers, dates, or URLs where relevant
+- [ ] HowTo includes `totalTime` in ISO 8601 format
+- [ ] Each HowToStep has `name`, `text`, and `image`
+- [ ] HowToStep images resolve and show the step visually
+- [ ] HowTo has `tool` and `supply` arrays where applicable
+- [ ] QAPage `acceptedAnswer` has highest `upvoteCount`
+- [ ] SpecialAnnouncements have `expires` date set
+- [ ] FAQ page is canonicalized (not duplicated across pages)
+- [ ] FAQ covers: what, price, comparison, how-to, troubleshooting
+
+## Tools
+
+- [Google FAQ Rich Results Test](https://search.google.com/test/rich-results)
+- [Schema.org FAQPage](https://schema.org/FAQPage)
+- [Schema.org HowTo](https://schema.org/HowTo)
+- [People Also Ask Scraper](https://alsoasked.com/) — mine real user questions
+- [Answer Socrates](https://answerthepublic.com/) — question research tool

--- a/skills/structured-entities/references/organization.md
+++ b/skills/structured-entities/references/organization.md
@@ -1,0 +1,190 @@
+# Organization & Brand Entity Patterns
+
+> Deep-reference for `skills/structured-entities/SKILL.md`
+
+## Why Organization Schema Matters for AI
+
+AI models build a knowledge graph of entities from structured data. An `Organization` schema is often the first entity a crawler resolves to understand who is behind a site. Incomplete or inconsistent Organization markup causes LLMs to hallucinate company details, mix up brands, or omit attribution in citations.
+
+## Core Organization Schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://example.com/#organization",
+  "name": "Acme Corp",
+  "legalName": "Acme Corporation Pty Ltd",
+  "url": "https://example.com",
+  "logo": {
+    "@type": "ImageObject",
+    "url": "https://example.com/logo.png",
+    "width": 512,
+    "height": 512
+  },
+  "description": "Acme Corp builds widgets for enterprise customers worldwide.",
+  "foundingDate": "2010",
+  "numberOfEmployees": { "@type": "QuantitativeValue", "value": 250 },
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Main St",
+    "addressLocality": "Melbourne",
+    "addressRegion": "VIC",
+    "postalCode": "3000",
+    "addressCountry": "AU"
+  },
+  "contactPoint": [
+    {
+      "@type": "ContactPoint",
+      "contactType": "customer support",
+      "email": "support@example.com",
+      "availableLanguage": "English"
+    }
+  ],
+  "sameAs": [
+    "https://www.linkedin.com/company/acme-corp",
+    "https://twitter.com/acmecorp",
+    "https://en.wikipedia.org/wiki/Acme_Corp"
+  ],
+  "knowsAbout": ["widget manufacturing", "enterprise solutions"],
+  "hasOfferCatalog": {
+    "@type": "OfferCatalog",
+    "name": "Acme Products",
+    "url": "https://example.com/products"
+  }
+}
+```
+
+## Brand Schema (for product brands)
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Brand",
+  "@id": "https://example.com/#brand",
+  "name": "Acme",
+  "logo": "https://example.com/brand-logo.png",
+  "description": "The Acme brand stands for reliability and innovation.",
+  "url": "https://example.com"
+}
+```
+
+## Entity Disambiguation with sameAs
+
+`sameAs` is the most powerful signal for AI disambiguation. Link to:
+
+| Source | Value |
+|--------|-------|
+| Wikipedia | Authoritative entity match |
+| Wikidata | Machine-readable identity |
+| LinkedIn | Business verification |
+| Crunchbase | Startup/company data |
+| Google Knowledge Graph | Direct KG link |
+| Industry registries | Domain authority |
+
+```json
+"sameAs": [
+  "https://en.wikipedia.org/wiki/Acme_Corp",
+  "https://www.wikidata.org/wiki/Q12345",
+  "https://www.linkedin.com/company/acme-corp",
+  "https://www.crunchbase.com/organization/acme-corp"
+]
+```
+
+## @id Consistency Rules
+
+The `@id` field is how LLMs resolve entity identity across pages. Violations cause split entities:
+
+```
+# WRONG — different @id on each page creates duplicate entities
+Homepage:  "@id": "https://example.com/"
+About:     "@id": "https://example.com/about/#org"
+Contact:   "@id": "https://example.com/contact/#organization"
+
+# RIGHT — canonical @id used everywhere
+All pages: "@id": "https://example.com/#organization"
+```
+
+## LocalBusiness Extension
+
+For location-based organizations:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": ["Organization", "LocalBusiness"],
+  "@id": "https://example.com/#organization",
+  "name": "Acme Melbourne",
+  "priceRange": "$$",
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      "opens": "09:00",
+      "closes": "17:00"
+    }
+  ],
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": -37.8136,
+    "longitude": 144.9631
+  }
+}
+```
+
+## WebSite + SearchAction
+
+Helps AI models surface your site's search capability:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": "https://example.com/#website",
+  "url": "https://example.com",
+  "name": "Acme Corp",
+  "publisher": { "@id": "https://example.com/#organization" },
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://example.com/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+```
+
+## Common Organization Schema Mistakes
+
+| Mistake | Impact | Fix |
+|---------|--------|-----|
+| Missing `@id` | Entity not resolved | Add canonical fragment URL |
+| Inconsistent `name` across pages | Brand confusion in AI | Normalize to one canonical name |
+| No `sameAs` links | Cannot disambiguate entity | Add Wikipedia + LinkedIn at minimum |
+| Logo URL returns 404 | Logo not cached by crawlers | Verify URL, use stable CDN |
+| Missing `legalName` | Compliance gap, trust signals | Add full registered name |
+| `description` over 160 chars | Truncated in AI summaries | Keep under 160 characters |
+| No `knowsAbout` | Topic association missing | Add 3–8 relevant topic strings |
+
+## Checklist
+
+- [ ] Organization `@id` is a consistent canonical URL fragment
+- [ ] `name` matches brand name used site-wide
+- [ ] `legalName` matches business registration
+- [ ] `logo` URL resolves and meets size requirements (min 112×112px)
+- [ ] `description` is under 160 characters and factual
+- [ ] `sameAs` includes Wikipedia and/or Wikidata
+- [ ] `sameAs` includes LinkedIn and primary social profiles
+- [ ] `address` is complete for LocalBusiness variants
+- [ ] `contactPoint` includes support contact type
+- [ ] `knowsAbout` lists 3–8 topic strings
+- [ ] WebSite schema links `publisher` to Organization `@id`
+- [ ] Schema present on homepage, About, and Contact pages
+
+## Tools
+
+- [Google Rich Results Test](https://search.google.com/test/rich-results)
+- [Schema.org Validator](https://validator.schema.org/)
+- [Wikidata Entity Lookup](https://www.wikidata.org/wiki/Special:Search)
+- [Google Knowledge Panel Tool](https://support.google.com/knowledgepanel/answer/9163198)

--- a/skills/structured-entities/references/product.md
+++ b/skills/structured-entities/references/product.md
@@ -1,0 +1,221 @@
+# Product & Service Entity Modeling
+
+> Deep-reference for `skills/structured-entities/SKILL.md`
+
+## Why Product Schema Drives AI Commerce Citations
+
+AI shopping assistants and answer engines use `Product` schema to surface pricing, availability, ratings, and comparison data. Without it, product pages are treated as generic content — never cited in product recommendation queries or price-check responses.
+
+## Core Product Schema
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "@id": "https://example.com/products/widget-pro/#product",
+  "name": "Widget Pro",
+  "description": "The Widget Pro is a premium enterprise widget with 5-year warranty and cloud sync.",
+  "sku": "WGT-PRO-001",
+  "gtin14": "00012345678905",
+  "mpn": "WGT-PRO-001",
+  "brand": {
+    "@type": "Brand",
+    "name": "Acme",
+    "@id": "https://example.com/#brand"
+  },
+  "manufacturer": {
+    "@id": "https://example.com/#organization"
+  },
+  "image": [
+    "https://example.com/images/widget-pro-front.jpg",
+    "https://example.com/images/widget-pro-side.jpg"
+  ],
+  "url": "https://example.com/products/widget-pro/",
+  "category": "Business > Enterprise Tools > Widgets",
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/products/widget-pro/",
+    "priceCurrency": "AUD",
+    "price": "299.00",
+    "priceValidUntil": "2025-12-31",
+    "availability": "https://schema.org/InStock",
+    "itemCondition": "https://schema.org/NewCondition",
+    "shippingDetails": {
+      "@type": "OfferShippingDetails",
+      "shippingRate": {
+        "@type": "MonetaryAmount",
+        "value": "0",
+        "currency": "AUD"
+      },
+      "deliveryTime": {
+        "@type": "ShippingDeliveryTime",
+        "handlingTime": { "@type": "QuantitativeValue", "minValue": 1, "maxValue": 2, "unitCode": "DAY" },
+        "transitTime": { "@type": "QuantitativeValue", "minValue": 2, "maxValue": 5, "unitCode": "DAY" }
+      }
+    },
+    "hasMerchantReturnPolicy": {
+      "@type": "MerchantReturnPolicy",
+      "returnPolicyCategory": "https://schema.org/MerchantReturnFiniteReturnWindow",
+      "merchantReturnDays": 30,
+      "returnMethod": "https://schema.org/ReturnByMail",
+      "returnFees": "https://schema.org/FreeReturn"
+    }
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.7",
+    "reviewCount": "128",
+    "bestRating": "5",
+    "worstRating": "1"
+  },
+  "review": [
+    {
+      "@type": "Review",
+      "reviewRating": { "@type": "Rating", "ratingValue": "5" },
+      "author": { "@type": "Person", "name": "Jane Smith" },
+      "reviewBody": "Best widget we've used. Setup was fast and support was excellent.",
+      "datePublished": "2024-11-15"
+    }
+  ]
+}
+```
+
+## SoftwareApplication Schema
+
+For SaaS and digital products:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "@id": "https://example.com/app/#software",
+  "name": "Widget Dashboard",
+  "operatingSystem": "Web, iOS, Android",
+  "applicationCategory": "BusinessApplication",
+  "offers": {
+    "@type": "Offer",
+    "price": "49.00",
+    "priceCurrency": "USD"
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.5",
+    "ratingCount": "320"
+  },
+  "featureList": "Real-time analytics, Multi-user access, API integration, Mobile apps",
+  "screenshot": "https://example.com/app/screenshot.png",
+  "softwareVersion": "3.2.1",
+  "releaseNotes": "https://example.com/app/changelog"
+}
+```
+
+## Multiple Offers (Pricing Tiers)
+
+```json
+"offers": [
+  {
+    "@type": "Offer",
+    "name": "Starter",
+    "price": "0",
+    "priceCurrency": "USD",
+    "description": "Up to 5 users, 10GB storage",
+    "availability": "https://schema.org/InStock"
+  },
+  {
+    "@type": "Offer",
+    "name": "Pro",
+    "price": "49.00",
+    "priceCurrency": "USD",
+    "description": "Unlimited users, 1TB storage, priority support",
+    "availability": "https://schema.org/InStock"
+  },
+  {
+    "@type": "Offer",
+    "name": "Enterprise",
+    "price": "0",
+    "priceCurrency": "USD",
+    "description": "Custom pricing — contact sales",
+    "availability": "https://schema.org/InStock"
+  }
+]
+```
+
+## Service Schema
+
+For agencies, consultancies, and professional services:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://example.com/services/seo-audit/#service",
+  "name": "SEO Audit Service",
+  "description": "Comprehensive technical SEO audit with actionable recommendations.",
+  "provider": { "@id": "https://example.com/#organization" },
+  "serviceType": "SEO Consulting",
+  "areaServed": "AU",
+  "offers": {
+    "@type": "Offer",
+    "price": "1500.00",
+    "priceCurrency": "AUD"
+  },
+  "hasOfferCatalog": {
+    "@type": "OfferCatalog",
+    "name": "SEO Services",
+    "itemListElement": [
+      { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Technical Audit" } },
+      { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Content Gap Analysis" } }
+    ]
+  }
+}
+```
+
+## AI Comparison Optimization
+
+AI models generate product comparison tables from structured data. Optimize for this:
+
+| Field | Why AI Uses It | Best Practice |
+|-------|----------------|---------------|
+| `name` | Comparison header | Concise, brand + model format |
+| `description` | Feature summary | Lead with differentiator, <160 chars |
+| `offers.price` | Price comparison | Always include currency |
+| `aggregateRating` | Trust signal | Include `reviewCount`, not just rating |
+| `featureList` | Feature diff table | Pipe-separated or comma list |
+| `category` | Group comparison | Use standard taxonomy strings |
+| `sku` / `gtin` | Product identity | Required for shopping integrations |
+
+## Common Product Schema Mistakes
+
+| Mistake | AI Impact | Fix |
+|---------|-----------|-----|
+| Price without `priceCurrency` | Ignored by shopping AI | Always pair price + currency |
+| Missing `priceValidUntil` | Stale pricing cached | Set 6–12 month future date |
+| No `availability` field | Product treated as discontinued | Always set InStock/OutOfStock |
+| `description` is marketing copy | Factual queries go unanswered | State specs, not slogans |
+| No `aggregateRating` | Not cited in best-of queries | Implement review markup |
+| Missing `brand` link | Product orphaned from brand entity | Link to Brand `@id` |
+| Single image only | Limited visual representation | Provide 3+ angles |
+
+## Checklist
+
+- [ ] `@id` uses canonical product URL fragment
+- [ ] `name` is brand + model format
+- [ ] `description` leads with key differentiator, under 160 chars
+- [ ] `sku` and/or `gtin` present for physical products
+- [ ] `brand` links to Brand `@id`
+- [ ] `offers.price` and `offers.priceCurrency` both present
+- [ ] `offers.priceValidUntil` set to future date
+- [ ] `offers.availability` set explicitly
+- [ ] `offers.shippingDetails` present for e-commerce
+- [ ] `offers.hasMerchantReturnPolicy` present
+- [ ] `aggregateRating` includes `reviewCount`
+- [ ] At least 3 product images
+- [ ] `featureList` populated for SoftwareApplication
+- [ ] All offers have `priceCurrency`
+
+## Tools
+
+- [Google Merchant Center Product Feed](https://support.google.com/merchants/answer/7052112)
+- [Schema.org Product Validator](https://validator.schema.org/)
+- [Google Rich Results Test](https://search.google.com/test/rich-results)
+- [Open Graph + Schema Debugger](https://www.opengraph.xyz/)


### PR DESCRIPTION
## Summary

Adds two new Phase 2 skill modules focused on AI-native content discovery and structured data markup:

### skills/answer-engine-optimization
- `SKILL.md` — core skill covering content structure, extractable prose, comparison pages, and FAQ patterns for AI citation
- `references/extractable-content.md` — deep reference on making content extractable by LLMs
- `references/comparison-pages.md` — strategies for AI-friendly product/service comparison pages
- `references/faq-patterns.md` — FAQ writing patterns optimized for AI answer extraction

### skills/structured-entities
- `SKILL.md` — core skill covering Schema.org entity markup (Organization, Product, FAQ, HowTo) for AI knowledge graph indexing
- `references/organization.md` — Organization & Brand entity patterns with sameAs disambiguation
- `references/product.md` — Product & Service entity modeling including SoftwareApplication and pricing tiers
- `references/faq-howto.md` — FAQ, HowTo & Q&A schema patterns with AI extraction guidelines

## Motivation

Builds on Phase 1 (ai-search-audit + llm-discovery) to teach agents how to reshape actual content and markup for AI-native retrieval and citation. Informed by Norg.ai research and current LLM citation patterns.