### PR TITLE
fix marketplace.json points to remote

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,7 @@
   "plugins": [
     {
       "name": "web-quality-skills",
-      "source": {
-        "source": "github",
-        "repo": "addyosmani/web-quality-skills"
-      },
+      "source": "./",
       "description": "Performance, Core Web Vitals, accessibility, SEO, and best-practices skills for any web stack."
     }
   ]


### PR DESCRIPTION
This causes `claude plugin install` to do a second `git clone` and fail in environments where there's no SSH keys set up for `git`.

<img width="3404" height="764" alt="CleanShot 2026-06-08 at 18 58 37@2x" src="https://github.com/user-attachments/assets/ae26975a-1ffc-46d4-af90-43d2704b9e9e" />

Upstream Claude Code issues:
- https://github.com/anthropics/claude-code/issues/18001
- https://github.com/anthropics/claude-code/issues/29722
- https://github.com/anthropics/claude-code/issues/31930
- https://github.com/anthropics/claude-code/issues/47088

The fix in the fork repo is confirmed to work:

<img width="1848" height="454" alt="CleanShot 2026-06-08 at 19 00 54@2x" src="https://github.com/user-attachments/assets/15407013-468e-4a9f-835f-121f00233e27" />
